### PR TITLE
Update MqttClient

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -1,6 +1,6 @@
 /*
 Copyright (c) 2013, 2014 Paolo Patierno
-Copyright (c) 2015 Salmane Bah
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 and Eclipse Distribution License v1.0 which accompany this distribution. 

--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -1,6 +1,6 @@
 /*
 Copyright (c) 2013, 2014 Paolo Patierno
-
+Copyright (c) 2015 Salmane Bah
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 and Eclipse Distribution License v1.0 which accompany this distribution. 
@@ -2051,14 +2051,8 @@ namespace uPLibrary.Networking.M2Mqtt
                                                     // notify received acknowledge from broker of a published message or subscribe/unsubscribe message
                                                     this.OnInternalEvent(internalEvent);
 
-                                                    // PUBACK received for PUBLISH message with QoS Level 1, remove from session state
-                                                    if ((msgInflight.Type == MqttMsgBase.MQTT_MSG_PUBLISH_TYPE) &&
-                                                        (this.session != null) &&
-#if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-                                                        (this.session.InflightMessages.Contains(msgContext.Key)))
-#else
-                                                        (this.session.InflightMessages.ContainsKey(msgContext.Key)))
-#endif
+                                                    // PUBACK received for PUBLISH message with QoS Level 1, remove from session state (if exists)
+                                                    if ((msgInflight.Type == MqttMsgBase.MQTT_MSG_PUBLISH_TYPE) && (this.session != null))
                                                     {
                                                         this.session.InflightMessages.Remove(msgContext.Key);
                                                     }
@@ -2094,13 +2088,8 @@ namespace uPLibrary.Networking.M2Mqtt
                                                         // if PUBACK for a PUBLISH message not received after retries, raise event for not published
                                                         if (msgInflight.Type == MqttMsgBase.MQTT_MSG_PUBLISH_TYPE)
                                                         {
-                                                            // PUBACK not received in time, PUBLISH retries failed, need to remove from session inflight messages too
-                                                            if ((this.session != null) &&
-#if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-                                                                (this.session.InflightMessages.Contains(msgContext.Key)))
-#else
-                                                                (this.session.InflightMessages.ContainsKey(msgContext.Key)))
-#endif
+                                                            // PUBACK not received in time, PUBLISH retries failed, need to remove from session inflight messages (if exists) too
+                                                            if (this.session != null)
                                                             {
                                                                 this.session.InflightMessages.Remove(msgContext.Key);
                                                             }
@@ -2193,13 +2182,8 @@ namespace uPLibrary.Networking.M2Mqtt
                                                     }
                                                     else
                                                     {
-                                                        // PUBREC not received in time, PUBLISH retries failed, need to remove from session inflight messages too
-                                                        if ((this.session != null) &&
-#if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-                                                            (this.session.InflightMessages.Contains(msgContext.Key)))
-#else
-                                                            (this.session.InflightMessages.ContainsKey(msgContext.Key)))
-#endif
+                                                        // PUBREC not received in time, PUBLISH retries failed, need to remove from session inflight messages too (exists)
+                                                        if (this.session != null)
                                                         {
                                                             this.session.InflightMessages.Remove(msgContext.Key);
                                                         }
@@ -2259,14 +2243,8 @@ namespace uPLibrary.Networking.M2Mqtt
                                                     // notify published message from broker and acknowledged
                                                     this.OnInternalEvent(internalEvent);
 
-                                                    // PUBREL received (and PUBCOMP sent) for PUBLISH message with QoS Level 2, remove from session state
-                                                    if ((msgInflight.Type == MqttMsgBase.MQTT_MSG_PUBLISH_TYPE) &&
-                                                        (this.session != null) &&
-#if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-                                                        (this.session.InflightMessages.Contains(msgContext.Key)))
-#else
-                                                        (this.session.InflightMessages.ContainsKey(msgContext.Key)))
-#endif
+                                                    // PUBREL received (and PUBCOMP sent) for PUBLISH message with QoS Level 2, remove from session state (if exists)
+                                                    if ((msgInflight.Type == MqttMsgBase.MQTT_MSG_PUBLISH_TYPE) && (this.session != null))
                                                     {
                                                         this.session.InflightMessages.Remove(msgContext.Key);
                                                     }
@@ -2322,14 +2300,8 @@ namespace uPLibrary.Networking.M2Mqtt
                                                     // notify received acknowledge from broker of a published message
                                                     this.OnInternalEvent(internalEvent);
 
-                                                    // PUBCOMP received for PUBLISH message with QoS Level 2, remove from session state
-                                                    if ((msgInflight.Type == MqttMsgBase.MQTT_MSG_PUBLISH_TYPE) &&
-                                                        (this.session != null) &&
-#if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-                                                        (this.session.InflightMessages.Contains(msgContext.Key)))
-#else
-                                                        (this.session.InflightMessages.ContainsKey(msgContext.Key)))
-#endif
+                                                    // PUBCOMP received for PUBLISH message with QoS Level 2, remove from session state (if exists)
+                                                    if ((msgInflight.Type == MqttMsgBase.MQTT_MSG_PUBLISH_TYPE) && (this.session != null))
                                                     {
                                                         this.session.InflightMessages.Remove(msgContext.Key);
                                                     }
@@ -2382,13 +2354,8 @@ namespace uPLibrary.Networking.M2Mqtt
                                                     }
                                                     else
                                                     {
-                                                        // PUBCOMP not received, PUBREL retries failed, need to remove from session inflight messages too
-                                                        if ((this.session != null) &&
-#if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-                                                            (this.session.InflightMessages.Contains(msgContext.Key)))
-#else
-                                                            (this.session.InflightMessages.ContainsKey(msgContext.Key)))
-#endif
+                                                        // PUBCOMP not received, PUBREL retries failed, need to remove from session inflight messages too (if exists)
+                                                        if (this.session != null)
                                                         {
                                                             this.session.InflightMessages.Remove(msgContext.Key);
                                                         }


### PR DESCRIPTION
Remove unnecessary checks that ensures that a given key is in the
session inflight messages before removing it. Knowing that
inflightMessages is a Hashtable that does nothing if a given key
doesn't exist and Remove is an O(1) operation.