### PR TITLE
Update MqttClient.cs

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -567,7 +567,17 @@ namespace uPLibrary.Networking.M2Mqtt
             // start thread for receiving messages from broker
             Fx.StartThread(this.ReceiveThread);
             
-            MqttMsgConnack connack = (MqttMsgConnack)this.SendReceive(connect);
+            MqttMsgConnack connack = null;
+            try
+            {
+                 connack = (MqttMsgConnack) this.SendReceive(connect);
+            }
+            catch (MqttCommunicationException e)
+            {
+                this.isRunning = false;
+                throw e;
+            }
+            
             // if connection accepted, start keep alive timer and 
             if (connack.ReturnCode == MqttMsgConnack.CONN_ACCEPTED)
             {


### PR DESCRIPTION
In case that the broker terminates the connection in the former implementation "SendReceive" throws a MqttCommunicationException, therefore the Connect-method is exited and "this.isRunning" remains true. Hence the threads are not terminated properly and keep hanging and consuming resources on error.

Example exception when HiveMQ closes the connection (e.g. when too less licenses are available):
uPLibrary.Networking.M2Mqtt.Exceptions.MqttCommunicationException: Eine Ausnahme vom Typ "uPLibrary.Networking.M2Mqtt.Exceptions.MqttCommunicationException" wurde ausgelöst.
   bei uPLibrary.Networking.M2Mqtt.MqttClient.SendReceive(Byte[] msgBytes, Int32 timeout) in c:\Users\ppatierno\Source\Repos\m2mqtt\M2Mqtt\MqttClient.cs:Zeile 1094.
   bei uPLibrary.Networking.M2Mqtt.MqttClient.SendReceive(MqttMsgBase msg, Int32 timeout) in c:\Users\ppatierno\Source\Repos\m2mqtt\M2Mqtt\MqttClient.cs:Zeile 1117.
   bei uPLibrary.Networking.M2Mqtt.MqttClient.Connect(String clientId, String username, String password, Boolean willRetain, Byte willQosLevel, Boolean willFlag, String willTopic, String willMessage, Boolean cleanSession, UInt16 keepAlivePeriod) in c:\Users\ppatierno\Source\Repos\m2mqtt\M2Mqtt\MqttClient.cs:Zeile 567.
   bei uPLibrary.Networking.M2Mqtt.MqttClient.Connect(String clientId, String username, String password) in c:\Users\ppatierno\Source\Repos\m2mqtt\M2Mqtt\MqttClient.cs:Zeile 494.